### PR TITLE
Configuring multiclass mask

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,22 @@ address different channels using the `Channels` enumerator.
 
 Usage
 -----
->>> octopus =  DaskOctopusLiteLoader('/path/to/your/data/')
->>> gfp = octopus["GFP"]
->>> gfp_filenames = octopus.files("GFP")
+>>> images =  DaskOctopusLiteLoader(path = '/path/to/your/data/',
+                                    crop = (1200,1600),
+                                    transforms = 'path/to/transform_array.npy',
+                                    remove_background = True)
+>>> gfp = images["GFP"]
+>>> gfp_filenames = images.files("GFP")
+
+
+Parameters
+  ----------
+  path : str
+      The path to the dataset.
+  crop : tuple, optional
+      An optional tuple which can be used to perform a centred crop on the data.
+  transforms : Path or np.ndarray
+      Transforms to be applied to the image stack.
+  remove_background : bool
+      Use a estimated polynomial surface to remove uneven illumination.
 ```

--- a/README.md
+++ b/README.md
@@ -11,4 +11,5 @@ Usage
 -----
 >>> octopus =  DaskOctopusLiteLoader('/path/to/your/data/')
 >>> gfp = octopus["GFP"]
+>>> gfp_filenames = octopus.files("GFP")
 ```

--- a/README.md
+++ b/README.md
@@ -11,5 +11,4 @@ Usage
 -----
 >>> octopus =  DaskOctopusLiteLoader('/path/to/your/data/')
 >>> gfp = octopus["GFP"]
->>> gfp_filenames = octopus.files("GFP")
 ```

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Parameters
       The path to the dataset.
   crop : tuple, optional
       An optional tuple which can be used to perform a centred crop on the data.
-  transforms : Path or np.ndarray
+  transforms : np.ndarray, optional
       Transforms to be applied to the image stack.
-  remove_background : bool
+  remove_background : bool, optional
       Use a estimated polynomial surface to remove uneven illumination.
 ```

--- a/octopuslite/reader.py
+++ b/octopuslite/reader.py
@@ -32,8 +32,8 @@ class DaskOctopusLiteLoader:
         The path to the dataset.
     crop : tuple, optional
         An optional tuple which can be used to perform a centred crop on the data.
-    transforms : Path or np.ndarray
-        Transforms to be applied to the image stack.
+    transforms : Path to transform matrix
+        Transform matrix (as np.ndarray) to be applied to the image stack.
     remove_background : bool
         Use a estimated polynomial surface to remove uneven illumination.
 
@@ -67,7 +67,7 @@ class DaskOctopusLiteLoader:
         self,
         path: str,
         crop: Optional[tuple] = None,
-        transforms: Optional[Union[os.PathLike, np.ndarray]] = None,
+        transforms: Optional[os.PathLike] = None,
         remove_background: bool = True,
     ):
         self.path = path
@@ -81,10 +81,7 @@ class DaskOctopusLiteLoader:
 
         # parse the files
         self._parse_files()
-        self._transformer = parse_transforms(
-            transforms,
-            #len(self._files[Channels.GFP]) #not currently needed
-        )
+        self._transformer = parse_transforms(transforms)
 
     def __contains__(self, channel):
         return channel in self.channels

--- a/octopuslite/reader.py
+++ b/octopuslite/reader.py
@@ -82,7 +82,8 @@ class DaskOctopusLiteLoader:
         # parse the files
         self._parse_files()
         self._transformer = parse_transforms(
-            transforms, len(self._files[Channels.GFP])
+            transforms,
+            #len(self._files[Channels.GFP]) #not currently needed
         )
 
     def __contains__(self, channel):

--- a/octopuslite/transform.py
+++ b/octopuslite/transform.py
@@ -23,7 +23,9 @@ class StackTransformer:
 
 
 
-def parse_transforms(path: os.PathLike, n: int) -> StackTransformer:
+def parse_transforms(path: os.PathLike,
+                    #n: int
+                    ) -> StackTransformer:
     """Parse a file or folder containing registration transforms.
 
     Parameters
@@ -31,8 +33,9 @@ def parse_transforms(path: os.PathLike, n: int) -> StackTransformer:
     path : PathLike
         A path to either a numpy file of transforms, or a folder containing
         transforms as XML files.
-    n : int
-        The number of frames in the movie.
+    # # may become necessary when alternate transform format is used
+    # n : int
+    #     The number of frames in the movie.
 
     Returns
     -------
@@ -50,7 +53,7 @@ def parse_transforms(path: os.PathLike, n: int) -> StackTransformer:
     # # get the transform files and then sort them by time
     # transform_files = [f for f in os.listdir(path) if f.endswith(".xml")]
     # transform_files.sort(key=lambda f: parse_filename(f)['time'])
-    #
+    # n = len(transform_files)
     # transforms = np.empty((n, 2), dtype=np.float32) * np.nan
     #
     # for file in transform_files:

--- a/octopuslite/transform.py
+++ b/octopuslite/transform.py
@@ -17,15 +17,12 @@ class StackTransformer:
         if self.transforms is None:
             return x
 
-        #tform = tf.AffineTransform(translation=self.transforms[idx, ...])
         tform = tf.AffineTransform(translation=self.transforms[idx, :2, 2])
         return tf.warp(x, tform, preserve_range=True)
 
 
 
-def parse_transforms(path: os.PathLike,
-                    #n: int
-                    ) -> StackTransformer:
+def parse_transforms(path: os.PathLike) -> StackTransformer:
     """Parse a file or folder containing registration transforms.
 
     Parameters
@@ -33,9 +30,6 @@ def parse_transforms(path: os.PathLike,
     path : PathLike
         A path to either a numpy file of transforms, or a folder containing
         transforms as XML files.
-    # # may become necessary when alternate transform format is used
-    # n : int
-    #     The number of frames in the movie.
 
     Returns
     -------

--- a/octopuslite/transform.py
+++ b/octopuslite/transform.py
@@ -17,7 +17,8 @@ class StackTransformer:
         if self.transforms is None:
             return x
 
-        tform = tf.AffineTransform(translation=self.transforms[idx, ...])
+        #tform = tf.AffineTransform(translation=self.transforms[idx, ...])
+        tform = tf.AffineTransform(translation=self.transforms[idx, :2, 2])
         return tf.warp(x, tform, preserve_range=True)
 
 

--- a/octopuslite/utils.py
+++ b/octopuslite/utils.py
@@ -20,7 +20,12 @@ class Channels(enum.Enum):
     RFP = 2
     IRFP = 3
     PHASE = 4
-    WEIGHTS = 98
+
+    WEIGHTS = 50
+
+    MASK_IRFP = 96
+    MASK_RFP = 97
+    MASK_GFP = 98
     MASK = 99
 
 


### PR DESCRIPTION
I've added extra mask channels, which is important for the latest commits i pushed to the multiclass object tracking, and I've (temporarily) commented out some transform function aspects as they were redundant with the .npy transforms I was using. I think going forward we should decide on a way to maybe load different classes of masks as one channel and also decide on a common transform input type, or expand it to accept different types. 