### PR TITLE
Configuring multiclass mask to not run image preprocessing

### DIFF
--- a/octopuslite/__init__.py
+++ b/octopuslite/__init__.py
@@ -1,1 +1,2 @@
 from .reader import DaskOctopusLiteLoader
+from .utils import image_generator

--- a/octopuslite/__init__.py
+++ b/octopuslite/__init__.py
@@ -1,2 +1,1 @@
 from .reader import DaskOctopusLiteLoader
-from .utils import image_generator

--- a/octopuslite/reader.py
+++ b/octopuslite/reader.py
@@ -118,8 +118,17 @@ class DaskOctopusLiteLoader:
         image = io.imread(fn)
 
         if self._transformer is not None:
-            t = int(parse_filename(fn)["time"])
-            image = self._transformer(image, t)
+            # need to use index of file as some frames may have been removed
+            channel = parse_filename(fn)["channel"]
+            files = [
+                os.path.join(self.path, f)
+                for f in os.listdir(self.path)
+                if f"channel{str(channel.value).zfill(3)}" in f
+                and f.endswith((".tif", ".tiff"))
+            ]
+            files.sort(key=lambda f: parse_filename(f)["time"])
+            idx = files.index(fn)
+            image = self._transformer(image, idx)
 
         if self._crop is not None:
 

--- a/octopuslite/reader.py
+++ b/octopuslite/reader.py
@@ -7,7 +7,13 @@ import numpy as np
 from skimage import io
 
 from .transform import parse_transforms
-from .utils import Channels, parse_filename, remove_background, remove_outliers, image_generator
+from .utils import (
+    Channels,
+    image_generator,
+    parse_filename,
+    remove_background,
+    remove_outliers,
+)
 
 
 class DaskOctopusLiteLoader:
@@ -66,7 +72,7 @@ class DaskOctopusLiteLoader:
         crop: Optional[tuple] = None,
         transforms: Optional[os.PathLike] = None,
         remove_background: bool = True,
-        remove_blank_frames: Union[tuple, bool] = None
+        remove_blank_frames: Union[tuple, bool] = None,
     ):
         self.path = path
         self._files = {}
@@ -76,7 +82,7 @@ class DaskOctopusLiteLoader:
         self._remove_background = remove_background
         self._remove_blank_frames = remove_blank_frames
 
-        if self._crop != None:
+        if self._crop is not None:
             print(f"Using cropping: {crop}")
 
         # parse the files
@@ -136,7 +142,7 @@ class DaskOctopusLiteLoader:
         # check channel to see if label
         channel = parse_filename(fn)["channel"]
         # labels cannot be preprocessed so return here
-        if channel.name.startswith(('MASK', 'WEIGHTS')):
+        if channel.name.startswith(("MASK", "WEIGHTS")):
             return image
 
         if self._remove_background:
@@ -144,7 +150,10 @@ class DaskOctopusLiteLoader:
             image = remove_background(cleaned)
             if self._crop is None:
                 import warnings
-                warnings.warn("Background removal works best on cropped, aligned image. Will fail on uncropped, aligned images due to border effect.")
+
+                warnings.warn(
+                    "Background removal works best on cropped, aligned image. Will fail on uncropped, aligned images due to border effect."
+                )
 
         return image
 
@@ -175,7 +184,7 @@ class DaskOctopusLiteLoader:
             else:
                 max, min = 200, 2
             blank_frames = []
-            for f, image in zip(files,image_generator(files)):
+            for f, image in zip(files, image_generator(files)):
                 if max < np.mean(image) or np.mean(image) < min:
                     blank_frames.append(parse_filename(f)["time"])
             for f in files:
@@ -201,7 +210,6 @@ class DaskOctopusLiteLoader:
         self._files = {k: v for k, v in channels.items() if v}
 
         # now set up the lazy loaders
-        #for channel, files in zip(channels, files):
         for channel, files in self._files.items():
             self._lazy_arrays[channel] = [
                 da.from_delayed(

--- a/octopuslite/reader.py
+++ b/octopuslite/reader.py
@@ -9,6 +9,7 @@ from skimage import io
 from .transform import parse_transforms
 from .utils import (
     Channels,
+    crop_image,
     image_generator,
     parse_filename,
     remove_background,
@@ -124,19 +125,13 @@ class DaskOctopusLiteLoader:
 
             assert isinstance(self._crop, tuple)
 
-            dims = image.ndim
-            shape = image.shape
             crop = np.array(self._crop).astype(np.int64)
 
             # check that we don't exceed any dimensions
-            assert all([crop[i] <= s for i, s in enumerate(shape)])
+            assert all([crop[i] <= s for i, s in enumerate(image.shape)])
 
-            # automagically build the slices for the array
-            cslice = lambda d: slice(
-                int((shape[d] - crop[d]) // 2), int((shape[d] - crop[d]) // 2 + crop[d])
-            )
-            crops = tuple([cslice(d) for d in range(dims)])
-            image = image[crops]
+            # crop the image
+            image = crop_image(image, crop)
 
         # check channel to see if label
         channel = parse_filename(fn)["channel"]

--- a/octopuslite/reader.py
+++ b/octopuslite/reader.py
@@ -177,7 +177,6 @@ class DaskOctopusLiteLoader:
             blank_frames = []
             for f, image in zip(files,image_generator(files)):
                 if max < np.mean(image) or np.mean(image) < min:
-                #if np.max(self._remove_blank_frames) < np.mean(image) or np.mean(image) < np.min(self._remove_blank_frames):
                     blank_frames.append(parse_filename(f)["time"])
             for f in files:
                 if parse_filename(f)["time"] in blank_frames:

--- a/octopuslite/reader.py
+++ b/octopuslite/reader.py
@@ -134,7 +134,7 @@ class DaskOctopusLiteLoader:
             cleaned = remove_outliers(image)
             image = remove_background(cleaned)
             if self._crop is None:
-                raise Exception ("Background removal works best on cropped, aligned image")
+                raise Exception("Background removal works best on cropped, aligned image")
 
         return image
 

--- a/octopuslite/reader.py
+++ b/octopuslite/reader.py
@@ -111,6 +111,10 @@ class DaskOctopusLiteLoader:
         """Load and crop the image."""
         image = io.imread(fn)
 
+        if self._transformer is not None:
+            t = int(parse_filename(fn)["time"])
+            image = self._transformer(image, t)
+
         if self._crop is not None:
 
             assert isinstance(self._crop, tuple)
@@ -134,10 +138,6 @@ class DaskOctopusLiteLoader:
         # labels cannot be preprocessed so return here
         if channel.name.startswith(('MASK', 'WEIGHTS')):
             return image
-
-        if self._transformer is not None:
-            t = int(parse_filename(fn)["time"])
-            image = self._transformer(image, t)
 
         if self._remove_background:
             cleaned = remove_outliers(image)

--- a/octopuslite/reader.py
+++ b/octopuslite/reader.py
@@ -33,11 +33,10 @@ class DaskOctopusLiteLoader:
         Transform matrix (as np.ndarray) to be applied to the image stack.
     remove_background : bool
         Use a estimated polynomial surface to remove uneven illumination.
-    remove_blank_frames : tuple or bool, optional
+    remove_blank_frames : tuple , optional
         An optional tuple of (minimum pixel value, maximum pixel value) that determines
         whether a frame is excluded on the premise that the mean of the image falls
-        outside of the pre-defined parameters. If no tuple is specified then the
-        default (min, max) of (2, 200) is used. Used to exclude frames where the
+        outside of the pre-defined parameters. Used to exclude frames where the
         light has not fired or has overexposed for some reason.
 
     Methods
@@ -72,7 +71,7 @@ class DaskOctopusLiteLoader:
         crop: Optional[tuple] = None,
         transforms: Optional[os.PathLike] = None,
         remove_background: bool = True,
-        remove_blank_frames: Union[tuple, bool] = None,
+        remove_blank_frames: Optional[tuple] = None,
     ):
         self.path = path
         self._files = {}
@@ -177,12 +176,10 @@ class DaskOctopusLiteLoader:
         channels = {k: [] for k in Channels}
 
         # remove blank frames and parse files
-        if self._remove_blank_frames is not None or False:
+        if self._remove_blank_frames is not None:
             if isinstance(self._remove_blank_frames, tuple):
                 max = np.max(self._remove_blank_frames)
                 min = np.min(self._remove_blank_frames)
-            else:
-                max, min = 200, 2
             blank_frames = []
             for f, image in zip(files, image_generator(files)):
                 if max < np.mean(image) or np.mean(image) < min:

--- a/octopuslite/reader.py
+++ b/octopuslite/reader.py
@@ -123,7 +123,7 @@ class DaskOctopusLiteLoader:
         # check channel to see if label
         channel = parse_filename(fn)["channel"]
         # labels cannot be preprocessed so return here
-        if channel.value >= 50:
+        if channel.name.startswith(('MASK', 'WEIGHTS')):
             return image
 
         if self._transformer is not None:
@@ -134,7 +134,7 @@ class DaskOctopusLiteLoader:
             cleaned = remove_outliers(image)
             image = remove_background(cleaned)
             if self._crop is None:
-                print("Background removal works best on cropped, aligned image")
+                raise Exception ("Background removal works best on cropped, aligned image")
 
         return image
 

--- a/octopuslite/reader.py
+++ b/octopuslite/reader.py
@@ -80,7 +80,10 @@ class DaskOctopusLiteLoader:
 
         # parse the files
         self._parse_files()
-        self._transformer = parse_transforms(transforms)
+        if transforms:
+            self._transformer = parse_transforms(transforms)
+        else:
+            self._transformer = None
 
     def __contains__(self, channel):
         return channel in self.channels

--- a/octopuslite/reader.py
+++ b/octopuslite/reader.py
@@ -113,12 +113,7 @@ class DaskOctopusLiteLoader:
         if self._transformer is not None:
             # need to use index of file as some frames may have been removed
             channel = parse_filename(fn)["channel"]
-            files = [
-                os.path.join(self.path, f)
-                for f in os.listdir(self.path)
-                if f"channel{str(channel.value).zfill(3)}" in f
-                and f.endswith((".tif", ".tiff"))
-            ]
+            files = self.files(channel.name)
             files.sort(key=lambda f: parse_filename(f)["time"])
             idx = files.index(fn)
             image = self._transformer(image, idx)

--- a/octopuslite/transform.py
+++ b/octopuslite/transform.py
@@ -35,7 +35,7 @@ def parse_transforms(path: os.PathLike) -> StackTransformer:
     if path is None:
         return StackTransformer(None)
 
-    if path.endswith(".npy"):
+    if str(path).endswith(".npy"):
         transforms = np.load(path)
         return StackTransformer(transforms)
 

--- a/octopuslite/transform.py
+++ b/octopuslite/transform.py
@@ -1,11 +1,10 @@
 import os
+
 # import xml.etree.ElementTree as ET
 import numpy as np
-
 import skimage.transform as tf
 
-
-from .utils import parse_filename
+# from .utils import parse_filename
 
 
 class StackTransformer:
@@ -19,7 +18,6 @@ class StackTransformer:
 
         tform = tf.AffineTransform(translation=self.transforms[idx, :2, 2])
         return tf.warp(x, tform, preserve_range=True)
-
 
 
 def parse_transforms(path: os.PathLike) -> StackTransformer:

--- a/octopuslite/transform.py
+++ b/octopuslite/transform.py
@@ -1,10 +1,7 @@
 import os
 
-# import xml.etree.ElementTree as ET
 import numpy as np
 import skimage.transform as tf
-
-# from .utils import parse_filename
 
 
 class StackTransformer:

--- a/octopuslite/utils.py
+++ b/octopuslite/utils.py
@@ -1,11 +1,10 @@
 import enum
 import os
 import re
-import numpy as np
-
-from scipy.ndimage import median_filter
 from typing import Tuple
 
+import numpy as np
+from scipy.ndimage import median_filter
 
 OCTOPUSLITE_FILEPATTERN = (
     "img_channel(?P<channel>[0-9]+)_position(?P<position>[0-9]+)"
@@ -38,11 +37,11 @@ def remove_outliers(x: np.ndarray) -> np.ndarray:
     Returns
     -------
     x : np.ndarray
-    	An image with the bright outlier pixels removed.
+        An image with the bright outlier pixels removed.
     """
     med_x = median_filter(x, size=2)
     mask = x > med_x
-    x = x * (1-mask) + (mask*med_x)
+    x = x * (1 - mask) + (mask * med_x)
     return x
 
 
@@ -63,7 +62,7 @@ def remove_background(x: np.ndarray) -> np.ndarray:
     x = x.astype(np.float32)
     bg = estimate_background(x[maskh, maskw])
     corrected = x[maskh, maskw] - bg
-    corrected = (corrected - np.min(corrected))
+    corrected = corrected - np.min(corrected)
     x[maskh, maskw] = corrected
     return x
 
@@ -83,19 +82,19 @@ def estimate_background(x: np.ndarray) -> np.ndarray:
     Returns
     -------
     background_estimate : np.ndarray
-    	A second order polynomial surface representing the estimated background
+        A second order polynomial surface representing the estimated background
         of the image.
     """
 
     # set up arrays for params and the output surface
-    A = np.zeros((x.shape[0]*x.shape[1], 6))
+    A = np.zeros((x.shape[0] * x.shape[1], 6))
     background_estimate = np.zeros((x.shape[1], x.shape[0]))
 
     u, v = np.meshgrid(
         np.arange(x.shape[1], dtype=np.float32),
         np.arange(x.shape[0], dtype=np.float32),
     )
-    A[:, 0] = 1.
+    A[:, 0] = 1.0
     A[:, 1] = np.reshape(u, (x.shape[0] * x.shape[1],))
     A[:, 2] = np.reshape(v, (x.shape[0] * x.shape[1],))
     A[:, 3] = A[:, 1] * A[:, 1]
@@ -110,7 +109,9 @@ def estimate_background(x: np.ndarray) -> np.ndarray:
     k = np.squeeze(np.array(np.dot(k, np.ravel(x))))
 
     # calculate the surface
-    background_estimate = k[0] + k[1]*u + k[2]*v + k[3]*u*u + k[4]*u*v + k[5]*v*v
+    background_estimate = (
+        k[0] + k[1] * u + k[2] * v + k[3] * u * u + k[4] * u * v + k[5] * v * v
+    )
     return background_estimate
 
 
@@ -132,8 +133,8 @@ def estimate_mask(x: np.ndarray) -> Tuple[slice]:
     if hasattr(x, "compute"):
         x = x.compute()
     nonzero = np.nonzero(x)
-    sh = slice(np.min(nonzero[0]), np.max(nonzero[0])+1, 1)
-    sw = slice(np.min(nonzero[1]), np.max(nonzero[1])+1, 1)
+    sh = slice(np.min(nonzero[0]), np.max(nonzero[0]) + 1, 1)
+    sw = slice(np.min(nonzero[1]), np.max(nonzero[1]) + 1, 1)
     return sh, sw
 
 
@@ -155,10 +156,10 @@ def parse_filename(filename: os.PathLike) -> dict:
 
     metadata = {
         "filename": filename,
-        "channel": Channels(int(params.group('channel'))),
-        "time": params.group('time'),
-        "position": params.group('position'),
-        "z": params.group('z'),
+        "channel": Channels(int(params.group("channel"))),
+        "time": params.group("time"),
+        "position": params.group("position"),
+        "z": params.group("z"),
         # "timestamp": os.stat(filename).st_mtime,
     }
 

--- a/octopuslite/utils.py
+++ b/octopuslite/utils.py
@@ -183,18 +183,41 @@ def image_generator(files, crop: Optional[tuple] = None):
     crop : tuple, optional
         An optional tuple which can be used to perform a centred crop on the
         image data.
+
+    Yields
+    ------
+    img : np.ndarray
+        An image loaded from the given filename at that iteration.
     """
-    shape = imread(files[0]).shape
-    dims = imread(files[0]).ndim
+
     if crop is None:
         for filename in files:
             img = imread(filename)
             yield img
     else:
-        cslice = lambda d: slice(
-            int((shape[d] - crop[d]) // 2), int((shape[d] - crop[d]) // 2 + crop[d])
-        )
-        crops = tuple([cslice(d) for d in range(dims)])
         for filename in files:
-            img = imread(filename)[crops]
+            img = crop_image(img, crop)
             yield img
+
+
+def crop_image(img, crop):
+    """Crops a central window from an input image given a crop area size tuple
+
+    Parameters
+    ----------
+    img : np.ndarray
+        Input image.
+    crop : tuple
+        An tuple which is used to perform a centred crop on the
+        image data.
+
+    """
+    shape = img.shape
+    dims = img.ndim
+    cslice = lambda d: slice(
+        int((shape[d] - crop[d]) // 2), int((shape[d] - crop[d]) // 2 + crop[d])
+    )
+    crops = tuple([cslice(d) for d in range(dims)])
+    img = img[crops]
+
+    return img

--- a/octopuslite/utils.py
+++ b/octopuslite/utils.py
@@ -1,10 +1,11 @@
 import enum
 import os
 import re
-from typing import Tuple
-
 import numpy as np
+
 from scipy.ndimage import median_filter
+from typing import Tuple, Optional
+from skimage.io import imread
 
 OCTOPUSLITE_FILEPATTERN = (
     "img_channel(?P<channel>[0-9]+)_position(?P<position>[0-9]+)"
@@ -37,11 +38,11 @@ def remove_outliers(x: np.ndarray) -> np.ndarray:
     Returns
     -------
     x : np.ndarray
-        An image with the bright outlier pixels removed.
+    	An image with the bright outlier pixels removed.
     """
     med_x = median_filter(x, size=2)
     mask = x > med_x
-    x = x * (1 - mask) + (mask * med_x)
+    x = x * (1-mask) + (mask*med_x)
     return x
 
 
@@ -62,7 +63,7 @@ def remove_background(x: np.ndarray) -> np.ndarray:
     x = x.astype(np.float32)
     bg = estimate_background(x[maskh, maskw])
     corrected = x[maskh, maskw] - bg
-    corrected = corrected - np.min(corrected)
+    corrected = (corrected - np.min(corrected))
     x[maskh, maskw] = corrected
     return x
 
@@ -82,19 +83,19 @@ def estimate_background(x: np.ndarray) -> np.ndarray:
     Returns
     -------
     background_estimate : np.ndarray
-        A second order polynomial surface representing the estimated background
+    	A second order polynomial surface representing the estimated background
         of the image.
     """
 
     # set up arrays for params and the output surface
-    A = np.zeros((x.shape[0] * x.shape[1], 6))
+    A = np.zeros((x.shape[0]*x.shape[1], 6))
     background_estimate = np.zeros((x.shape[1], x.shape[0]))
 
     u, v = np.meshgrid(
         np.arange(x.shape[1], dtype=np.float32),
         np.arange(x.shape[0], dtype=np.float32),
     )
-    A[:, 0] = 1.0
+    A[:, 0] = 1.
     A[:, 1] = np.reshape(u, (x.shape[0] * x.shape[1],))
     A[:, 2] = np.reshape(v, (x.shape[0] * x.shape[1],))
     A[:, 3] = A[:, 1] * A[:, 1]
@@ -109,9 +110,7 @@ def estimate_background(x: np.ndarray) -> np.ndarray:
     k = np.squeeze(np.array(np.dot(k, np.ravel(x))))
 
     # calculate the surface
-    background_estimate = (
-        k[0] + k[1] * u + k[2] * v + k[3] * u * u + k[4] * u * v + k[5] * v * v
-    )
+    background_estimate = k[0] + k[1]*u + k[2]*v + k[3]*u*u + k[4]*u*v + k[5]*v*v
     return background_estimate
 
 
@@ -133,8 +132,8 @@ def estimate_mask(x: np.ndarray) -> Tuple[slice]:
     if hasattr(x, "compute"):
         x = x.compute()
     nonzero = np.nonzero(x)
-    sh = slice(np.min(nonzero[0]), np.max(nonzero[0]) + 1, 1)
-    sw = slice(np.min(nonzero[1]), np.max(nonzero[1]) + 1, 1)
+    sh = slice(np.min(nonzero[0]), np.max(nonzero[0])+1, 1)
+    sw = slice(np.min(nonzero[1]), np.max(nonzero[1])+1, 1)
     return sh, sw
 
 
@@ -156,11 +155,44 @@ def parse_filename(filename: os.PathLike) -> dict:
 
     metadata = {
         "filename": filename,
-        "channel": Channels(int(params.group("channel"))),
-        "time": params.group("time"),
-        "position": params.group("position"),
-        "z": params.group("z"),
+        "channel": Channels(int(params.group('channel'))),
+        "time": params.group('time'),
+        "position": params.group('position'),
+        "z": params.group('z'),
         # "timestamp": os.stat(filename).st_mtime,
     }
 
     return metadata
+
+def image_generator(files, crop: Optional[tuple] = None):
+    """Image generator for iterative procesess
+
+    For many timelapse data related procesess (such as calculating mean values
+    and localising objects), using a generator function to iterative load single
+    frames is quicker than computing each frame and calculating using dask.
+
+    Parameters
+    ----------
+    files : list
+        A list of image files which you wish to iterate over. Can be easily
+        generated using the DaskOctopusLiteLoader function 'files'.
+        E.g. image_generator(DaskOctopusLiteLoader.files('channel name'))
+    crop : tuple, optional
+        An optional tuple which can be used to perform a centred crop on the
+        data.
+    """
+    #get dims
+    shape = imread(files[0]).shape
+    dims = imread(files[0]).ndim
+    if crop == None:
+        for filename in files:
+            img = imread(filename)
+            yield img
+    else:
+        cslice = lambda d: slice(
+            int((shape[d] - crop[d]) // 2),
+            int((shape[d] - crop[d]) // 2 + crop[d]))
+        crops = tuple([cslice(d) for d in range(dims)])
+        for filename in files:
+            img = imread(filename)[crops]
+            yield img

--- a/octopuslite/utils.py
+++ b/octopuslite/utils.py
@@ -1,10 +1,10 @@
 import enum
 import os
 import re
-import numpy as np
+from typing import Optional, Tuple
 
+import numpy as np
 from scipy.ndimage import median_filter
-from typing import Tuple, Optional
 from skimage.io import imread
 
 OCTOPUSLITE_FILEPATTERN = (
@@ -38,11 +38,11 @@ def remove_outliers(x: np.ndarray) -> np.ndarray:
     Returns
     -------
     x : np.ndarray
-    	An image with the bright outlier pixels removed.
+        An image with the bright outlier pixels removed.
     """
     med_x = median_filter(x, size=2)
     mask = x > med_x
-    x = x * (1-mask) + (mask*med_x)
+    x = x * (1 - mask) + (mask * med_x)
     return x
 
 
@@ -63,7 +63,7 @@ def remove_background(x: np.ndarray) -> np.ndarray:
     x = x.astype(np.float32)
     bg = estimate_background(x[maskh, maskw])
     corrected = x[maskh, maskw] - bg
-    corrected = (corrected - np.min(corrected))
+    corrected = corrected - np.min(corrected)
     x[maskh, maskw] = corrected
     return x
 
@@ -83,19 +83,19 @@ def estimate_background(x: np.ndarray) -> np.ndarray:
     Returns
     -------
     background_estimate : np.ndarray
-    	A second order polynomial surface representing the estimated background
+        A second order polynomial surface representing the estimated background
         of the image.
     """
 
     # set up arrays for params and the output surface
-    A = np.zeros((x.shape[0]*x.shape[1], 6))
+    A = np.zeros((x.shape[0] * x.shape[1], 6))
     background_estimate = np.zeros((x.shape[1], x.shape[0]))
 
     u, v = np.meshgrid(
         np.arange(x.shape[1], dtype=np.float32),
         np.arange(x.shape[0], dtype=np.float32),
     )
-    A[:, 0] = 1.
+    A[:, 0] = 1.0
     A[:, 1] = np.reshape(u, (x.shape[0] * x.shape[1],))
     A[:, 2] = np.reshape(v, (x.shape[0] * x.shape[1],))
     A[:, 3] = A[:, 1] * A[:, 1]
@@ -110,7 +110,9 @@ def estimate_background(x: np.ndarray) -> np.ndarray:
     k = np.squeeze(np.array(np.dot(k, np.ravel(x))))
 
     # calculate the surface
-    background_estimate = k[0] + k[1]*u + k[2]*v + k[3]*u*u + k[4]*u*v + k[5]*v*v
+    background_estimate = (
+        k[0] + k[1] * u + k[2] * v + k[3] * u * u + k[4] * u * v + k[5] * v * v
+    )
     return background_estimate
 
 
@@ -132,8 +134,8 @@ def estimate_mask(x: np.ndarray) -> Tuple[slice]:
     if hasattr(x, "compute"):
         x = x.compute()
     nonzero = np.nonzero(x)
-    sh = slice(np.min(nonzero[0]), np.max(nonzero[0])+1, 1)
-    sw = slice(np.min(nonzero[1]), np.max(nonzero[1])+1, 1)
+    sh = slice(np.min(nonzero[0]), np.max(nonzero[0]) + 1, 1)
+    sw = slice(np.min(nonzero[1]), np.max(nonzero[1]) + 1, 1)
     return sh, sw
 
 
@@ -155,14 +157,15 @@ def parse_filename(filename: os.PathLike) -> dict:
 
     metadata = {
         "filename": filename,
-        "channel": Channels(int(params.group('channel'))),
-        "time": params.group('time'),
-        "position": params.group('position'),
-        "z": params.group('z'),
+        "channel": Channels(int(params.group("channel"))),
+        "time": params.group("time"),
+        "position": params.group("position"),
+        "z": params.group("z"),
         # "timestamp": os.stat(filename).st_mtime,
     }
 
     return metadata
+
 
 def image_generator(files, crop: Optional[tuple] = None):
     """Image generator for iterative procesess
@@ -179,18 +182,18 @@ def image_generator(files, crop: Optional[tuple] = None):
         E.g. image_generator(DaskOctopusLiteLoader.files('channel name'))
     crop : tuple, optional
         An optional tuple which can be used to perform a centred crop on the
-        data.
+        image data.
     """
     shape = imread(files[0]).shape
     dims = imread(files[0]).ndim
-    if crop == None:
+    if crop is None:
         for filename in files:
             img = imread(filename)
             yield img
     else:
         cslice = lambda d: slice(
-            int((shape[d] - crop[d]) // 2),
-            int((shape[d] - crop[d]) // 2 + crop[d]))
+            int((shape[d] - crop[d]) // 2), int((shape[d] - crop[d]) // 2 + crop[d])
+        )
         crops = tuple([cslice(d) for d in range(dims)])
         for filename in files:
             img = imread(filename)[crops]

--- a/octopuslite/utils.py
+++ b/octopuslite/utils.py
@@ -181,7 +181,6 @@ def image_generator(files, crop: Optional[tuple] = None):
         An optional tuple which can be used to perform a centred crop on the
         data.
     """
-    #get dims
     shape = imread(files[0]).shape
     dims = imread(files[0]).ndim
     if crop == None:

--- a/octopuslite/utils.py
+++ b/octopuslite/utils.py
@@ -1,11 +1,10 @@
 import enum
 import os
 import re
-from typing import Optional, Tuple
+from typing import Tuple
 
 import numpy as np
 from scipy.ndimage import median_filter
-from skimage.io import imread
 
 OCTOPUSLITE_FILEPATTERN = (
     "img_channel(?P<channel>[0-9]+)_position(?P<position>[0-9]+)"
@@ -167,41 +166,7 @@ def parse_filename(filename: os.PathLike) -> dict:
     return metadata
 
 
-def image_generator(files, crop: Optional[tuple] = None):
-    """Image generator for iterative procesess
-
-    For many timelapse data related procesess (such as calculating mean values
-    and localising objects), using a generator function to iterative load single
-    frames is quicker than computing each frame and calculating using dask.
-
-    Parameters
-    ----------
-    files : list
-        A list of image files which you wish to iterate over. Can be easily
-        generated using the DaskOctopusLiteLoader function 'files'.
-        E.g. image_generator(DaskOctopusLiteLoader.files('channel name'))
-    crop : tuple, optional
-        An optional tuple which can be used to perform a centred crop on the
-        image data.
-
-    Yields
-    ------
-    img : np.ndarray
-        An image loaded from the given filename at that iteration.
-    """
-
-    if crop is None:
-        for filename in files:
-            img = imread(filename)
-            yield img
-    else:
-        for filename in files:
-            img = imread(filename)
-            img = crop_image(img, crop)
-            yield img
-
-
-def crop_image(img, crop):
+def crop_image(img: np.ndarray, crop: Tuple[int]) -> np.ndarray:
     """Crops a central window from an input image given a crop area size tuple
 
     Parameters
@@ -211,6 +176,11 @@ def crop_image(img, crop):
     crop : tuple
         An tuple which is used to perform a centred crop on the
         image data.
+
+    Returns
+    -------
+    img : np.ndarray
+        The cropped image.
 
     """
     shape = img.shape

--- a/octopuslite/utils.py
+++ b/octopuslite/utils.py
@@ -196,6 +196,7 @@ def image_generator(files, crop: Optional[tuple] = None):
             yield img
     else:
         for filename in files:
+            img = imread(filename)
             img = crop_image(img, crop)
             yield img
 


### PR DESCRIPTION
#9 sorted so that weights and masks do not run the transform or background removal, also configured it so that background removal and transforms werent mutually exclusive options