### PR TITLE
Mutliclass mask changes

### DIFF
--- a/octopuslite/__init__.py
+++ b/octopuslite/__init__.py
@@ -1,1 +1,2 @@
 from .reader import DaskOctopusLiteLoader
+from .utils import image_generator

--- a/octopuslite/transform.py
+++ b/octopuslite/transform.py
@@ -1,11 +1,7 @@
 import os
-# import xml.etree.ElementTree as ET
+
 import numpy as np
-
 import skimage.transform as tf
-
-
-from .utils import parse_filename
 
 
 class StackTransformer:
@@ -19,7 +15,6 @@ class StackTransformer:
 
         tform = tf.AffineTransform(translation=self.transforms[idx, :2, 2])
         return tf.warp(x, tform, preserve_range=True)
-
 
 
 def parse_transforms(path: os.PathLike) -> StackTransformer:


### PR DESCRIPTION
Quite a lot in this pr:

- configured loader to not preprocess masks
- added an image generator function to `utils.py` to aid in batch processing of images when not viewing them (such as in object localisation of mask stacks)
- added a parameter to not load blank/overexposed frames but this is quite time consuming (i do not rely on this in segment-classify-track repo, instead just remove these images from main image dir before alignment)
- also realised crop and transform functions were the wrong way round